### PR TITLE
Add deduplicate merge tag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     },
     "require": {
         "php": "^8.1|^8.2|^8.3",
-        "statamic/cms": "^4.50"
+        "statamic/cms": "^4.50|^5.0"
     },
     "require-dev": {
         "laravel/pint": "^1.13",

--- a/src/Deduplicate.php
+++ b/src/Deduplicate.php
@@ -22,38 +22,4 @@ class Deduplicate
 
         return $this;
     }
-
-    protected function deduplicateApply()
-    {
-        if (! $this->params->get('deduplicate', false)) {
-            return;
-        }
-
-        $ids = app('deduplicate')->fetch();
-
-        if ($this->params->has('id:not_in')) {
-            $tagIds = $this->params['id:not_in'];
-            if (is_string($tagIds)) {
-                $tagIds = explode('|', $tagIds);
-            }
-            $ids = array_merge($ids, $tagIds);
-        }
-
-        $this->params->put('id:not_in', $ids);
-    }
-
-    protected function deduplicateUpdate($entries)
-    {
-        if (! $this->params->get('deduplicate', false)) {
-            return;
-        }
-
-        if ($as = $this->params->get('as')) {
-            $entries = $entries[$as];
-        }
-
-        $ids = $entries->pluck('id')->all();
-
-        app('deduplicate')->merge($ids);
-    }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -8,10 +8,14 @@ use Tv2regionerne\StatamicDeduplicate\Actions\DeduplicateActions;
 
 class ServiceProvider extends AddonServiceProvider
 {
+    protected $tags = [
+        Tags\Deduplicate::class,
+    ];
+
     public function register()
     {
         $this->app->singleton('deduplicate', function () {
-            return new Deduplicate();
+            return new Deduplicate;
         });
 
         Collection::hook('init', DeduplicateActions::filter());

--- a/src/Tags/Deduplicate.php
+++ b/src/Tags/Deduplicate.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tv2regionerne\StatamicDeduplicate\Tags;
+
+use Statamic\Tags\Tags;
+
+class Deduplicate extends Tags
+{
+    public function wildcard($id)
+    {
+        $this->params['ids'] = [$id];
+
+        $this->merge();
+    }
+
+    public function merge()
+    {
+        $ids = $this->params->get('ids');
+        if (is_string($ids)) {
+            $ids = explode('|', $ids);
+        }
+
+        app('deduplicate')->merge($ids);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -87,7 +87,7 @@ abstract class TestCase extends OrchestraTestCase
         foreach ($configs as $config) {
             $app['config']->set(
                 "statamic.$config",
-                require (__DIR__."/../vendor/statamic/cms/config/{$config}.php")
+                require(__DIR__."/../vendor/statamic/cms/config/{$config}.php")
             );
         }
 


### PR DESCRIPTION
Adds a tag that allows you to manually push IDs to dedeuplicate:

```antlers
{{ deduplicate:8da81e3d-c2d0-48ac-8f77-f30cc9a57dae }}

{{ deduplicate:merge ids="8da81e3d-c2d0-48ac-8f77-f30cc9a57dae|1bf7eb88-0156-4a1e-ae08-c13e87e24fd8" }}

{{ deduplicate:merge :ids="ids" }}
```

Also bumps composer dependency and cleans up some unused methods.

Closes https://github.com/tv2regionerne/statamic-deduplicate/issues/5